### PR TITLE
Fix: show correct opta model variant in OPC/UA field "ModelName".

### DIFF
--- a/examples/opcua_server/opcua_server.ino
+++ b/examples/opcua_server/opcua_server.ino
@@ -206,7 +206,7 @@ void setup()
       UA_LOG_INFO(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "Arduino Opta Variant: %s", opcua::ArduinoOptaVariant::toString(opta_type).c_str());
 
       /* Define the Arduino Opta as a OPC/UA object. */
-      arduino_opta_opcua = opcua::ArduinoOpta::create(opc_ua_server);
+      arduino_opta_opcua = opcua::ArduinoOpta::create(opc_ua_server, opta_type);
       if (!arduino_opta_opcua) {
         UA_LOG_ERROR(UA_Log_Stdout, UA_LOGCATEGORY_SERVER, "opcua::ArduinoOpta::create(...) failed");
         return;

--- a/src/ArduinoOpta.cpp
+++ b/src/ArduinoOpta.cpp
@@ -57,7 +57,7 @@ ArduinoOpta::ArduinoOpta(UA_Server * server, UA_NodeId const & node_id)
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/
 
-ArduinoOpta::SharedPtr ArduinoOpta::create(UA_Server * server)
+ArduinoOpta::SharedPtr ArduinoOpta::create(UA_Server * server, ArduinoOptaVariant::Type const opta_type)
 {
   UA_StatusCode rc = UA_STATUSCODE_GOOD;
 
@@ -103,7 +103,7 @@ ArduinoOpta::SharedPtr ArduinoOpta::create(UA_Server * server)
   }
 
   UA_VariableAttributes modelAttr = UA_VariableAttributes_default;
-  UA_String modelName = UA_STRING("Arduino Opta WiFi");
+  UA_String modelName = UA_STRING((char *)ArduinoOptaVariant::toString(opta_type).c_str());
   UA_Variant_setScalar(&modelAttr.value, &modelName, &UA_TYPES[UA_TYPES_STRING]);
   modelAttr.displayName = UA_LOCALIZEDTEXT("en-US", "ModelName");
   rc = UA_Server_addVariableNode(server,

--- a/src/ArduinoOpta.h
+++ b/src/ArduinoOpta.h
@@ -22,6 +22,7 @@
 #include "AnalogInputManager.h"
 #include "DigitalInputManager.h"
 #include "UserButton.h"
+#include "ArduinoOptaVariant.h"
 
 /**************************************************************************************
  * NAMESPACE
@@ -39,7 +40,7 @@ class ArduinoOpta
 public:
   typedef std::shared_ptr<ArduinoOpta> SharedPtr;
 
-  static SharedPtr create(UA_Server * server);
+  static SharedPtr create(UA_Server * server, ArduinoOptaVariant::Type const opta_type);
 
   ArduinoOpta(UA_Server * server, UA_NodeId const & node_id);
 


### PR DESCRIPTION
Previously it did only always show "Arduino Opta WiFi", regardless of the actual opta model variant.

![image](https://github.com/bcmi-labs/Arduino_open62541/assets/3931733/3aef010c-37b2-4c7a-a847-abbadac37cc2)
