### PR TITLE
Fix: adjust to now semantically correct usage of "getPwmPeriod" and "getPwmPulse".

### DIFF
--- a/examples/opta_opcua_server/opta_opcua_server.ino
+++ b/examples/opta_opcua_server/opta_opcua_server.ino
@@ -371,11 +371,11 @@ void setup()
               },
               [i, p](void) -> uint32_t
               {
-                return reinterpret_cast<AnalogExpansion *>(OptaController.getExpansionPtr(i))->getPwmPeriod(p - OA_PWM_CH_FIRST);
+                return reinterpret_cast<AnalogExpansion *>(OptaController.getExpansionPtr(i))->getPwmPeriod(p);
               },
               [i, p](void) -> uint32_t
               {
-                return reinterpret_cast<AnalogExpansion *>(OptaController.getExpansionPtr(i))->getPwmPulse(p - OA_PWM_CH_FIRST);
+                return reinterpret_cast<AnalogExpansion *>(OptaController.getExpansionPtr(i))->getPwmPulse(p);
               });
             pwm_output_num++;
           }


### PR DESCRIPTION
This requires >= Arduino_Opta_Blueprint v0.2.4.

This is a consequence of https://github.com/arduino-libraries/Arduino_Opta_Blueprint/pull/11 .